### PR TITLE
Add vimwiki-cli to Related Tools

### DIFF
--- a/docs/Related Tools.html
+++ b/docs/Related Tools.html
@@ -4,6 +4,7 @@
 <link rel="Stylesheet" type="text/css" href="style.css">
 <title>Related Tools</title>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 
@@ -184,6 +185,16 @@ Todo management using Jabberbot. The linked GitHub repository seems to
 <li>
 Python tool to generate an index and convert wiki files to Markdown
     format. This has not been updated in 6 years.
+
+</ul>
+<li>
+<a href="https://github.com/sstallion/vimwiki-cli">vimwiki-cli</a>
+
+<ul>
+<li>
+Python CLI that provides a front-end for interactive editor commands and
+      can be used to automate repetitive tasks such as rebuilding tag metadata
+      and generating links, all from the command line.
 
 </ul>
 </ul>

--- a/wiki/Related Tools.wiki
+++ b/wiki/Related Tools.wiki
@@ -62,3 +62,7 @@ that is missing!
 - [[https://github.com/zweifisch/vimwiki-tools|vimwiki-tools]]
     - Python tool to generate an index and convert wiki files to Markdown
     format. This has not been updated in 6 years.
+- [[https://github.com/sstallion/vimwiki-cli|vimwiki-cli]]
+    - Python CLI that provides a front-end for interactive editor commands and
+      can be used to automate repetitive tasks such as rebuilding tag metadata
+      and generating links, all from the command line.


### PR DESCRIPTION
This PR adds [vimwiki-cli](https://githhub.com/sstallion/vimwiki-cli) to the `Related Tools` page. HTML was regenerated using the `Vimwiki2HTML` command.