### PR TITLE
Add `link.vim`

### DIFF
--- a/docs/Related Tools.html
+++ b/docs/Related Tools.html
@@ -28,6 +28,14 @@ Select a date to open a diary page.
 
 </ul>
 <li>
+<a href="https://github.com/qadzek/link.vim">link.vim</a>
+
+<ul>
+<li>
+Keep long URLs out of your way in Vimwiki (Markdown syntax).
+
+</ul>
+<li>
 <a href="https://github.com/tbabej/taskwiki">taskwiki</a>
 
 <ul>

--- a/wiki/Related Tools.wiki
+++ b/wiki/Related Tools.wiki
@@ -8,6 +8,8 @@ that is missing!
 
 - [[https://github.com/mattn/calendar-vim|calendar-vim]]
     - Select a date to open a diary page.
+- [[https://github.com/qadzek/link.vim|link.vim]]
+    - Keep long URLs out of your way in Vimwiki (Markdown syntax).
 - [[https://github.com/tbabej/taskwiki|taskwiki]]
     - Integration with [[https://taskwarrior.org/|taskwarrior]] for task
       management. This only supports the default syntax.


### PR DESCRIPTION
Originally, I created this plugin for Vimwiki (Markdown syntax), but it has since evolved into a more general plugin that can handle both Markdown links and plaintext links (emails, text files, etc.).

In my opinion, it's a very useful plugin if you have a lot of long URLs in your Vimwiki.